### PR TITLE
Build time toggle to redirect errors to stderr

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -9,4 +9,9 @@ LT_INIT
 AC_C_RESTRICT
 AC_PROG_CC_C99
 
+AC_ARG_ENABLE([log-stderr],
+              [AS_HELP_STRING([--disable-log-stderr], [Disable logging errors to stderr])],
+              [],
+              [AC_DEFINE([LOG_STDERR], [1])])
+
 AC_OUTPUT([Makefile src/liblog.pc])

--- a/src/log.c
+++ b/src/log.c
@@ -68,11 +68,16 @@ static void _logger(enum log_level level, const char *format, va_list pargs)
 		_get_time();
 
 	if (FLAG_SET(LIBLOG_FLAG_CONSOLE)) {
+	  #ifdef LOG_STDERR
 		if (level == LIBLOG_ERROR) {
 			_stream_log(stderr, format, pargs, need > 1);
 		} else {
 			_stream_log(stdout, format, pargs, need > 1);
 		}
+		#endif
+		#ifndef LOG_STDERR
+		_stream_log(stdout, format, pargs, need > 1);
+		#endif
 	}
 
 	if (FLAG_SET(LIBLOG_FLAG_FILE) && _logfile != NULL)

--- a/src/log.c
+++ b/src/log.c
@@ -65,7 +65,11 @@ static void _logger(enum log_level level, const char *format, va_list pargs)
 	int need = FLAG_SET(LIBLOG_FLAG_SYSLOG) + FLAG_SET(LIBLOG_FLAG_CONSOLE) + (FLAG_SET(LIBLOG_FLAG_FILE) && _logfile != NULL);
 
 	if (FLAG_SET(LIBLOG_FLAG_CONSOLE)) {
-		_stream_log(stdout, format, pargs, need > 1);
+		if (level == LIBLOG_ERROR) {
+			_stream_log(stderr, format, pargs, need > 1);
+		} else {
+			_stream_log(stdout, format, pargs, need > 1);
+		}
 	}
 
 	if (FLAG_SET(LIBLOG_FLAG_FILE) && _logfile != NULL)

--- a/test/test.c
+++ b/test/test.c
@@ -1,0 +1,16 @@
+#include <liblog.h>
+
+#define NAME "sharpd"
+#define LOGFILE "/tmp/liblog-test.log"
+
+int main(int argc, char *argv[]) {
+  int logopts = LIBLOG_FLAG_MICROTIMESTAMP | LIBLOG_FLAG_CONSOLE;
+  
+  log_open(NAME, LOGFILE, logopts);
+  log_level(LIBLOG_DEBUG);
+  
+  log_info("Info entry.");
+  log_error("Error entry.");
+
+  log_close();
+}


### PR DESCRIPTION
This PR adds a compile time toggle to send log_error() to stderr.
I've tested with it enabled and disabled to confirm that the outputs behave as expected.
